### PR TITLE
BlockStorage

### DIFF
--- a/hyena-api/src/lib.rs
+++ b/hyena-api/src/lib.rs
@@ -222,10 +222,7 @@ impl Reply {
     fn list_columns(catalog: &Catalog) -> Reply {
         let cm: &ColumnMap = catalog.as_ref();
         let names = cm.iter()
-            .map(|(id, column)| match **column {
-                TyBlockType::Memory(typ) => ReplyColumn::new(typ, *id, format!("{}", column)),
-                TyBlockType::Memmap(typ) => ReplyColumn::new(typ, *id, format!("{}", column)),
-            })
+            .map(|(id, column)| ReplyColumn::new(column.block_type(), *id, format!("{}", column)))
             .collect();
         Reply::ListColumns(names)
     }

--- a/hyena-api/src/lib.rs
+++ b/hyena-api/src/lib.rs
@@ -20,7 +20,7 @@ use error::*;
 
 use bincode::{Error as BinError, deserialize};
 use hyena_engine::{BlockType, Catalog, Column, ColumnMap, BlockData, Append, Scan,
-ScanTsRange, BlockStorageType as TyBlockType, ColumnId, TimestampFragment, Fragment,
+ScanTsRange, BlockStorage, ColumnId, TimestampFragment, Fragment,
 ScanFilterOp as HScanFilterOp, ScanFilter as HScanFilter};
 
 use hyena_common::ty::Uuid;
@@ -232,7 +232,7 @@ impl Reply {
             return Reply::AddColumn(Err(Error::ColumnNameCannotBeEmpty));
         }
 
-        let column = Column::new(TyBlockType::Memmap(request.column_type),
+        let column = Column::new(BlockStorage::Memmap(request.column_type),
                                  request.column_name.as_str());
         let id = catalog.next_id();
         info!("Adding column {}:{:?} with id {}",
@@ -342,8 +342,8 @@ impl Reply {
                         Some(DataTriple {
                             column_id: column,
                             column_type: match **col {
-                                TyBlockType::Memory(t) => t,
-                                TyBlockType::Memmap(t) => t,
+                                BlockStorage::Memory(t) => t,
+                                BlockStorage::Memmap(t) => t,
                             },
                             data: fragment
                         })
@@ -389,8 +389,8 @@ impl Reply {
             .iter()
             .map(|(id, c)| {
                 let t = match **c {
-                    TyBlockType::Memory(t) => t,
-                    TyBlockType::Memmap(t) => t,
+                    BlockStorage::Memory(t) => t,
+                    BlockStorage::Memmap(t) => t,
                 };
                 ReplyColumn {
                     typ: t,
@@ -482,7 +482,7 @@ mod tests {
         mod list_columns {
             use super::*;
             use super::Reply::ListColumns;
-            use hyena_engine::BlockStorageType::*;
+            use hyena_engine::BlockStorage::*;
             use hyena_engine::BlockType;
 
             #[test]
@@ -605,7 +605,7 @@ mod tests {
             use super::*;
             use hyena_engine::Fragment;
             use hyena_engine::BlockType::{I8Dense, U8Sparse};
-            use hyena_engine::BlockStorageType::Memory;
+            use hyena_engine::BlockStorage::Memory;
 
             #[test]
             fn creates_source_group() {
@@ -802,7 +802,7 @@ mod tests {
             use super::Reply::RefreshCatalog;
             use hyena_engine::{BlockType, Fragment};
             use hyena_engine::BlockType::{I8Dense, U8Sparse};
-            use hyena_engine::BlockStorageType::Memory;
+            use hyena_engine::BlockStorage::Memory;
 
             #[test]
             fn handles_empty_catalog() {

--- a/hyena-engine/src/datastore/catalog.rs
+++ b/hyena-engine/src/datastore/catalog.rs
@@ -1,5 +1,5 @@
 use error::*;
-use ty::BlockStorageType;
+use ty::BlockStorage;
 use hyena_common::ty::MIN_TIMESTAMP;
 use block::BlockType;
 use storage::manager::PartitionGroupManager;
@@ -50,8 +50,8 @@ impl<'cat> Catalog<'cat> {
     }
 
     fn ensure_default_columns(&mut self) -> Result<()> {
-        let ts_column = Column::new(BlockStorageType::Memmap(BlockType::U64Dense), "timestamp");
-        let source_column = Column::new(BlockStorageType::Memory(BlockType::I32Dense), "source_id");
+        let ts_column = Column::new(BlockStorage::Memmap(BlockType::U64Dense), "timestamp");
+        let source_column = Column::new(BlockStorage::Memory(BlockType::I32Dense), "source_id");
         let mut map = HashMap::new();
         map.insert(0, ts_column);
         map.insert(1, source_column);

--- a/hyena-engine/src/datastore/catalog.rs
+++ b/hyena-engine/src/datastore/catalog.rs
@@ -1,5 +1,5 @@
 use error::*;
-use ty::BlockType as TyBlockType;
+use ty::BlockStorageType;
 use hyena_common::ty::MIN_TIMESTAMP;
 use block::BlockType;
 use storage::manager::PartitionGroupManager;
@@ -50,8 +50,8 @@ impl<'cat> Catalog<'cat> {
     }
 
     fn ensure_default_columns(&mut self) -> Result<()> {
-        let ts_column = Column::new(TyBlockType::Memmap(BlockType::U64Dense), "timestamp");
-        let source_column = Column::new(TyBlockType::Memory(BlockType::I32Dense), "source_id");
+        let ts_column = Column::new(BlockStorageType::Memmap(BlockType::U64Dense), "timestamp");
+        let source_column = Column::new(BlockStorageType::Memory(BlockType::I32Dense), "source_id");
         let mut map = HashMap::new();
         map.insert(0, ts_column);
         map.insert(1, source_column);

--- a/hyena-engine/src/datastore/column.rs
+++ b/hyena-engine/src/datastore/column.rs
@@ -1,4 +1,5 @@
 use ty::BlockStorageType;
+use block::BlockType;
 use std::fmt::{Display, Error as FmtError, Formatter};
 use std::ops::Deref;
 use std::result::Result as StdResult;
@@ -15,6 +16,10 @@ impl Column {
             ty,
             name: name.to_owned(),
         }
+    }
+
+    pub fn block_type(&self) -> BlockType {
+        *self.ty
     }
 }
 

--- a/hyena-engine/src/datastore/column.rs
+++ b/hyena-engine/src/datastore/column.rs
@@ -1,4 +1,4 @@
-use ty::BlockStorageType;
+use ty::{BlockStorage, BlockStorageType};
 use block::BlockType;
 use std::fmt::{Display, Error as FmtError, Formatter};
 use std::ops::Deref;
@@ -6,12 +6,12 @@ use std::result::Result as StdResult;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Column {
-    pub(crate) ty: BlockStorageType,
+    pub(crate) ty: BlockStorage,
     pub(crate) name: String,
 }
 
 impl Column {
-    pub fn new(ty: BlockStorageType, name: &str) -> Column {
+    pub fn new(ty: BlockStorage, name: &str) -> Column {
         Column {
             ty,
             name: name.to_owned(),
@@ -21,10 +21,14 @@ impl Column {
     pub fn block_type(&self) -> BlockType {
         *self.ty
     }
+
+    pub fn storage_type(&self) -> BlockStorageType {
+        self.ty.storage_type()
+    }
 }
 
 impl Deref for Column {
-    type Target = BlockStorageType;
+    type Target = BlockStorage;
 
     fn deref(&self) -> &Self::Target {
         &self.ty

--- a/hyena-engine/src/datastore/column.rs
+++ b/hyena-engine/src/datastore/column.rs
@@ -1,16 +1,16 @@
-use ty::BlockType as TyBlockType;
+use ty::BlockStorageType;
 use std::fmt::{Display, Error as FmtError, Formatter};
 use std::ops::Deref;
 use std::result::Result as StdResult;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Column {
-    pub(crate) ty: TyBlockType,
+    pub(crate) ty: BlockStorageType,
     pub(crate) name: String,
 }
 
 impl Column {
-    pub fn new(ty: TyBlockType, name: &str) -> Column {
+    pub fn new(ty: BlockStorageType, name: &str) -> Column {
         Column {
             ty,
             name: name.to_owned(),
@@ -19,7 +19,7 @@ impl Column {
 }
 
 impl Deref for Column {
-    type Target = TyBlockType;
+    type Target = BlockStorageType;
 
     fn deref(&self) -> &Self::Target {
         &self.ty

--- a/hyena-engine/src/datastore/partition.rs
+++ b/hyena-engine/src/datastore/partition.rs
@@ -2,8 +2,8 @@ use error::*;
 use uuid::Uuid;
 
 use block::{BlockData, BufferHead, SparseIndex};
-use ty::{BlockHeadMap, BlockId, BlockMap, BlockStorageType, BlockStorageTypeMap,
-ColumnId, RowId};
+use ty::{BlockHeadMap, BlockMap, BlockStorage, BlockStorageMap, BlockStorageMapType, ColumnId,
+RowId};
 use hyena_common::ty::Timestamp;
 use std::path::{Path, PathBuf};
 use std::cmp::{max, min};
@@ -83,7 +83,7 @@ impl<'part> Partition<'part> {
 
     pub(crate) fn append<'frag>(
         &mut self,
-        blockmap: &BlockStorageTypeMap,
+        blockmap: &BlockStorageMap,
         frags: &BlockRefData<'frag>,
         offset: SparseIndex,
     ) -> Result<usize> {
@@ -446,8 +446,8 @@ impl<'part> Partition<'part> {
     }
 
     #[inline]
-    pub fn ensure_blocks(&mut self, type_map: &BlockStorageTypeMap) -> Result<()> {
-        let fmap = type_map
+    pub fn ensure_blocks(&mut self, storage_map: &BlockStorageMap) -> Result<()> {
+        let fmap = storage_map
             .iter()
             .filter_map(|(block_id, block_type)| {
                 if self.blocks.contains_key(block_id) {
@@ -474,7 +474,7 @@ impl<'part> Partition<'part> {
     // TODO: to be benched
     fn prepare_blocks<'i, P>(
         root: P,
-        type_map: &'i HashMap<BlockId, BlockStorageType>,
+        storage_map: &'i BlockStorageMapType,
     ) -> Result<BlockMap<'part>>
     where
         P: AsRef<Path> + Sync,
@@ -482,10 +482,10 @@ impl<'part> Partition<'part> {
 //         &'i BT: IntoIterator<Item = (BlockId, BlockType)>,
     {
 
-        type_map
+        storage_map
             .iter()
             .map(|(block_id, block_type)| match *block_type {
-                BlockStorageType::Memory(bty) => {
+                BlockStorage::Memory(bty) => {
                     use ty::block::memory::Block;
 
                     Block::create(bty)
@@ -493,7 +493,7 @@ impl<'part> Partition<'part> {
                         .with_context(|_| "Unable to create in-memory block")
                         .map_err(|e| e.into())
                 }
-                BlockStorageType::Memmap(bty) => {
+                BlockStorage::Memmap(bty) => {
                     use ty::block::mmap::Block;
 
                     Block::create(&root, bty, *block_id)
@@ -515,7 +515,7 @@ impl<'part> Partition<'part> {
     fn serialize<P: AsRef<Path>>(partition: &Partition<'part>, meta: P) -> Result<()> {
         let meta = meta.as_ref();
 
-        let blocks: BlockStorageTypeMap = (&partition.blocks).into();
+        let blocks: BlockStorageMap = (&partition.blocks).into();
         let heads = partition
             .blocks
             .iter()
@@ -546,7 +546,7 @@ impl<'part> Partition<'part> {
             bail!("Cannot find partition metadata {:?}", meta);
         }
 
-        let (mut partition, blocks, heads): (Partition, BlockStorageTypeMap, BlockHeadMap) =
+        let (mut partition, blocks, heads): (Partition, BlockStorageMap, BlockHeadMap) =
             deserialize!(file meta)
                 .with_context(|_| "Failed to read partition metadata")?;
 
@@ -584,8 +584,7 @@ impl<'part> Drop for Partition<'part> {
 mod tests {
     use super::*;
     use std::collections::hash_map::HashMap;
-    use ty::BlockId;
-    use ty::block::{Block, BlockStorageType};
+    use ty::block::{Block, BlockStorage, BlockId};
     use std::fmt::Debug;
     use hyena_test::random::timestamp::{RandomTimestamp, RandomTimestampGen};
     use block::BlockData;
@@ -594,7 +593,7 @@ mod tests {
 
     macro_rules! block_test_impl_mem {
         ($base: ident, $($variant: ident),* $(,)*) => {{
-            use self::BlockStorageType::Memory;
+            use self::BlockStorage::Memory;
             let mut idx = 0;
 
             hashmap! {
@@ -607,7 +606,7 @@ mod tests {
 
     macro_rules! block_test_impl_mmap {
         ($base: ident, $($variant: ident),* $(,)*) => {{
-            use self::BlockStorageType::Memmap;
+            use self::BlockStorage::Memmap;
             let mut idx = 0;
 
             hashmap! {
@@ -632,7 +631,7 @@ mod tests {
         (mem {$($key:expr => $value:expr),+}) => {{
             hashmap! {
                 $(
-                    $key => BlockStorageType::Memory($value),
+                    $key => BlockStorage::Memory($value),
                  )+
             }
         }};
@@ -640,7 +639,7 @@ mod tests {
         (mmap {$($key:expr => $value:expr),+}) => {{
             hashmap! {
                 $(
-                    $key => BlockStorageType::Memmap($value),
+                    $key => BlockStorage::Memmap($value),
                  )+
             }
         }}
@@ -662,7 +661,7 @@ mod tests {
         };
     }
 
-    fn block_write_test_impl(short_map: &BlockStorageTypeMap, long_map: &BlockStorageTypeMap) {
+    fn block_write_test_impl(short_map: &BlockStorageMap, long_map: &BlockStorageMap) {
         use rayon::iter::IntoParallelRefMutIterator;
         use block::BlockData;
 
@@ -738,7 +737,7 @@ mod tests {
 
     fn ts_init<'part, P>(
         root: P,
-        ts_ty: BlockStorageType,
+        ts_ty: BlockStorage,
         count: usize,
     ) -> (Partition<'part>, Timestamp, Timestamp)
     where
@@ -789,7 +788,7 @@ mod tests {
         (part, (*ts_min).into(), (*ts_max).into())
     }
 
-    fn scan_ts(ts_ty: BlockStorageType) {
+    fn scan_ts(ts_ty: BlockStorage) {
 
         let root = tempdir!();
 
@@ -803,7 +802,7 @@ mod tests {
         assert_eq!(ret_ts_max, ts_max);
     }
 
-    fn update_meta(ts_ty: BlockStorageType) {
+    fn update_meta(ts_ty: BlockStorage) {
 
         let root = tempdir!();
 
@@ -893,7 +892,7 @@ mod tests {
             macro_rules! materialize_test_init {
                 () => {{
                     use block::BlockType;
-                    use self::BlockStorageType::Memory;
+                    use self::BlockStorage::Memory;
                     use ty::fragment::FragmentRef;
 
                     let root = tempdir!();
@@ -977,7 +976,7 @@ mod tests {
         use std::mem::size_of;
         use params::BLOCK_SIZE;
         use std::iter::FromIterator;
-        use self::BlockStorageType::Memory;
+        use self::BlockStorage::Memory;
 
         // reserve 20 records on timestamp
         let count = BLOCK_SIZE / size_of::<u64>() - 20;
@@ -1073,7 +1072,7 @@ mod tests {
         where
             T: Debug + Clone,
             Block<'block>: PartialEq<T>,
-            BlockStorageTypeMap: From<HashMap<BlockId, T>>,
+            BlockStorageMap: From<HashMap<BlockId, T>>,
         {
             let root = tempdir!();
             let ts = <Timestamp as Default>::default();
@@ -1098,8 +1097,8 @@ mod tests {
 
         pub(super) fn heads<'part, 'block, P>(
             root: P,
-            type_map: HashMap<BlockId, BlockStorageType>,
-            ts_ty: BlockStorageType,
+            type_map: HashMap<BlockId, BlockStorage>,
+            ts_ty: BlockStorage,
             count: usize,
         ) where
             'part: 'block,
@@ -1149,7 +1148,7 @@ mod tests {
         where
             T: Debug + Clone,
             Block<'block>: PartialEq<T>,
-            BlockStorageTypeMap: From<HashMap<BlockId, T>>,
+            BlockStorageMap: From<HashMap<BlockId, T>>,
         {
             let root = tempdir!();
             let ts = <Timestamp as Default>::default();
@@ -1176,8 +1175,8 @@ mod tests {
 
         pub(super) fn heads<'part, 'block, P>(
             root: P,
-            type_map: HashMap<BlockId, BlockStorageType>,
-            ts_ty: BlockStorageType,
+            type_map: HashMap<BlockId, BlockStorage>,
+            ts_ty: BlockStorage,
             count: usize,
         ) where
             'part: 'block,
@@ -1222,7 +1221,7 @@ mod tests {
     mod memory {
         use super::*;
         use block::BlockType;
-        use self::BlockStorageType::Memory;
+        use self::BlockStorage::Memory;
 
         #[test]
         fn scan_ts() {
@@ -1252,7 +1251,7 @@ mod tests {
 
         mod serialize {
             use super::*;
-            use self::BlockStorageType::Memory;
+            use self::BlockStorage::Memory;
 
             #[test]
             fn blocks() {
@@ -1274,7 +1273,7 @@ mod tests {
 
         mod deserialize {
             use super::*;
-            use self::BlockStorageType::Memory;
+            use self::BlockStorage::Memory;
 
             #[test]
             fn blocks() {
@@ -1300,7 +1299,7 @@ mod tests {
     mod mmap {
         use super::*;
         use block::BlockType;
-        use self::BlockStorageType::Memory;
+        use self::BlockStorage::Memory;
 
         #[test]
         fn scan_ts() {
@@ -1330,7 +1329,7 @@ mod tests {
 
         mod serialize {
             use super::*;
-            use self::BlockStorageType::Memory;
+            use self::BlockStorage::Memory;
 
             #[test]
             fn blocks() {
@@ -1352,7 +1351,7 @@ mod tests {
 
         mod deserialize {
             use super::*;
-            use self::BlockStorageType::Memory;
+            use self::BlockStorage::Memory;
 
             #[test]
             fn blocks() {

--- a/hyena-engine/src/datastore/partition_group.rs
+++ b/hyena-engine/src/datastore/partition_group.rs
@@ -11,7 +11,7 @@ use std::sync::RwLock;
 use params::{SourceId, PARTITION_GROUP_METADATA};
 use mutator::append::Append;
 use scanner::{Scan, ScanResult};
-use ty::block::{BlockTypeMap, BlockTypeMapTy};
+use ty::block::{BlockStorageTypeMap, BlockStorageTypeMapTy};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use super::partition::Partition;
@@ -87,14 +87,14 @@ impl<'pg> PartitionGroup<'pg> {
 
         let columns = catalog.as_ref();
 
-        let typemap: BlockTypeMap = colindices
+        let typemap: BlockStorageTypeMap = colindices
             .iter()
             .map(|colidx| if let Some(col) = columns.get(colidx) {
                 Ok((*colidx, **col))
             } else {
                 bail!("column {} not found", colidx)
             })
-            .collect::<Result<BlockTypeMapTy>>()
+            .collect::<Result<BlockStorageTypeMapTy>>()
             .with_context(|_| err_msg("failed to prepare all columns"))?
             .into();
 

--- a/hyena-engine/src/datastore/partition_group.rs
+++ b/hyena-engine/src/datastore/partition_group.rs
@@ -11,7 +11,7 @@ use std::sync::RwLock;
 use params::{SourceId, PARTITION_GROUP_METADATA};
 use mutator::append::Append;
 use scanner::{Scan, ScanResult};
-use ty::block::{BlockStorageTypeMap, BlockStorageTypeMapTy};
+use ty::block::{BlockStorageMap, BlockStorageMapType};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use super::partition::Partition;
@@ -87,14 +87,14 @@ impl<'pg> PartitionGroup<'pg> {
 
         let columns = catalog.as_ref();
 
-        let typemap: BlockStorageTypeMap = colindices
+        let typemap: BlockStorageMap = colindices
             .iter()
             .map(|colidx| if let Some(col) = columns.get(colidx) {
                 Ok((*colidx, **col))
             } else {
                 bail!("column {} not found", colidx)
             })
-            .collect::<Result<BlockStorageTypeMapTy>>()
+            .collect::<Result<BlockStorageMapType>>()
             .with_context(|_| err_msg("failed to prepare all columns"))?
             .into();
 

--- a/hyena-engine/src/datastore/tests/append.rs
+++ b/hyena-engine/src/datastore/tests/append.rs
@@ -476,7 +476,7 @@ mod benches {
 
 mod dense {
     use super::*;
-    use ty::block::BlockType::Memmap;
+    use ty::block::BlockStorageType::Memmap;
 
     #[test]
     fn ts_only() {
@@ -1041,7 +1041,7 @@ mod dense {
 
 mod sparse {
     use super::*;
-    use ty::block::BlockType::Memmap;
+    use ty::block::BlockStorageType::Memmap;
 
     #[test]
     fn current_only() {

--- a/hyena-engine/src/datastore/tests/append.rs
+++ b/hyena-engine/src/datastore/tests/append.rs
@@ -476,7 +476,7 @@ mod benches {
 
 mod dense {
     use super::*;
-    use ty::block::BlockStorageType::Memmap;
+    use ty::block::BlockStorage::Memmap;
 
     #[test]
     fn ts_only() {
@@ -1041,7 +1041,7 @@ mod dense {
 
 mod sparse {
     use super::*;
-    use ty::block::BlockStorageType::Memmap;
+    use ty::block::BlockStorage::Memmap;
 
     #[test]
     fn current_only() {

--- a/hyena-engine/src/datastore/tests/mod.rs
+++ b/hyena-engine/src/datastore/tests/mod.rs
@@ -1,5 +1,5 @@
 use error::*;
-use ty::BlockStorageType;
+use ty::BlockStorage;
 use hyena_common::ty::Timestamp;
 use block::SparseIndex;
 use storage::manager::{PartitionGroupManager, PartitionManager};

--- a/hyena-engine/src/datastore/tests/mod.rs
+++ b/hyena-engine/src/datastore/tests/mod.rs
@@ -1,5 +1,5 @@
 use error::*;
-use ty::BlockType as TyBlockType;
+use ty::BlockStorageType;
 use hyena_common::ty::Timestamp;
 use block::SparseIndex;
 use storage::manager::{PartitionGroupManager, PartitionManager};

--- a/hyena-engine/src/datastore/tests/scan.rs
+++ b/hyena-engine/src/datastore/tests/scan.rs
@@ -16,7 +16,7 @@ mod full {
 
         (init count $count: expr) => {{
             use block::BlockType;
-            use ty::block::BlockStorageType::Memmap;
+            use ty::block::BlockStorage::Memmap;
             use ty::fragment::Fragment;
 
             let now = <Timestamp as Default>::default();
@@ -62,7 +62,7 @@ mod full {
 
         (init sparse count $count: expr, $sparse_ratio: expr) => {{
             use block::BlockType;
-            use ty::block::BlockStorageType::Memmap;
+            use ty::block::BlockStorage::Memmap;
             use ty::fragment::Fragment;
 
             let now = <Timestamp as Default>::default();
@@ -267,7 +267,7 @@ mod full {
     mod pruning {
         use super::*;
         use block::BlockType;
-        use self::BlockStorageType::Memmap;
+        use self::BlockStorage::Memmap;
         use ty::fragment::Fragment;
         use scanner::{ScanResult, ScanFilter};
 
@@ -512,7 +512,7 @@ mod minimal {
     use super::*;
     use ty::fragment::Fragment;
     use scanner::ScanFilter;
-    use self::BlockStorageType::Memmap;
+    use self::BlockStorage::Memmap;
 
     /// Helper for 'minimal' scan tests
     ///

--- a/hyena-engine/src/datastore/tests/scan.rs
+++ b/hyena-engine/src/datastore/tests/scan.rs
@@ -15,8 +15,8 @@ mod full {
         };
 
         (init count $count: expr) => {{
-            use block::BlockType as BlockTy;
-            use ty::block::BlockType::Memmap;
+            use block::BlockType;
+            use ty::block::BlockStorageType::Memmap;
             use ty::fragment::Fragment;
 
             let now = <Timestamp as Default>::default();
@@ -35,12 +35,12 @@ mod full {
 
             let td = append_test_impl!(
                 hashmap! {
-                    0 => Column::new(Memmap(BlockTy::U64Dense), "ts"),
-                    1 => Column::new(Memmap(BlockTy::U32Dense), "source"),
-                    2 => Column::new(Memmap(BlockTy::U8Dense), "col1"),
-                    3 => Column::new(Memmap(BlockTy::U16Dense), "col2"),
-                    4 => Column::new(Memmap(BlockTy::U32Dense), "col3"),
-                    5 => Column::new(Memmap(BlockTy::U64Dense), "col4"),
+                    0 => Column::new(Memmap(BlockType::U64Dense), "ts"),
+                    1 => Column::new(Memmap(BlockType::U32Dense), "source"),
+                    2 => Column::new(Memmap(BlockType::U8Dense), "col1"),
+                    3 => Column::new(Memmap(BlockType::U16Dense), "col2"),
+                    4 => Column::new(Memmap(BlockType::U32Dense), "col3"),
+                    5 => Column::new(Memmap(BlockType::U64Dense), "col4"),
                 },
                 now,
                 [
@@ -61,8 +61,8 @@ mod full {
         };
 
         (init sparse count $count: expr, $sparse_ratio: expr) => {{
-            use block::BlockType as BlockTy;
-            use ty::block::BlockType::Memmap;
+            use block::BlockType;
+            use ty::block::BlockStorageType::Memmap;
             use ty::fragment::Fragment;
 
             let now = <Timestamp as Default>::default();
@@ -95,12 +95,12 @@ mod full {
 
             let td = append_test_impl!(
                 hashmap! {
-                    0 => Column::new(Memmap(BlockTy::U64Dense), "ts"),
-                    1 => Column::new(Memmap(BlockTy::U32Dense), "source"),
-                    2 => Column::new(Memmap(BlockTy::U8Sparse), "col1"),
-                    3 => Column::new(Memmap(BlockTy::U16Sparse), "col2"),
-                    4 => Column::new(Memmap(BlockTy::U32Sparse), "col3"),
-                    5 => Column::new(Memmap(BlockTy::U64Sparse), "col4"),
+                    0 => Column::new(Memmap(BlockType::U64Dense), "ts"),
+                    1 => Column::new(Memmap(BlockType::U32Dense), "source"),
+                    2 => Column::new(Memmap(BlockType::U8Sparse), "col1"),
+                    3 => Column::new(Memmap(BlockType::U16Sparse), "col2"),
+                    4 => Column::new(Memmap(BlockType::U32Sparse), "col3"),
+                    5 => Column::new(Memmap(BlockType::U64Sparse), "col4"),
                 },
                 now,
                 [
@@ -266,8 +266,8 @@ mod full {
 
     mod pruning {
         use super::*;
-        use block::BlockType as BlockTy;
-        use self::TyBlockType::Memmap;
+        use block::BlockType;
+        use self::BlockStorageType::Memmap;
         use ty::fragment::Fragment;
         use scanner::{ScanResult, ScanFilter};
 
@@ -284,8 +284,8 @@ mod full {
             let td = append_test_impl!(
                 [1],
                 hashmap! {
-                    0 => Column::new(Memmap(BlockTy::U64Dense), "ts"),
-                    1 => Column::new(Memmap(BlockTy::U32Dense), "source_id"),
+                    0 => Column::new(Memmap(BlockType::U64Dense), "ts"),
+                    1 => Column::new(Memmap(BlockType::U32Dense), "source_id"),
                 },
                 now,
                 [
@@ -512,7 +512,7 @@ mod minimal {
     use super::*;
     use ty::fragment::Fragment;
     use scanner::ScanFilter;
-    use self::TyBlockType::Memmap;
+    use self::BlockStorageType::Memmap;
 
     /// Helper for 'minimal' scan tests
     ///
@@ -644,7 +644,7 @@ mod minimal {
                 ]
             ),* $(,)* ]
         ) => {{
-            use block::BlockType as BlockTy;
+            use block::BlockType;
 
             let now = $ts;
 
@@ -653,19 +653,19 @@ mod minimal {
 
             // ts column is awlays present
             let mut schema = hashmap! {
-                0 => Column::new(Memmap(BlockTy::U64Dense), "ts"),
+                0 => Column::new(Memmap(BlockType::U64Dense), "ts"),
             };
 
             // adjust schema first
 
             $(
                 schema.insert($dense_schema_idx,
-                    Column::new(Memmap(BlockTy::$dense_ty), $dense_name));
+                    Column::new(Memmap(BlockType::$dense_ty), $dense_name));
             )*
 
             $(
                 schema.insert($sparse_schema_idx,
-                    Column::new(Memmap(BlockTy::$sparse_ty), $sparse_name));
+                    Column::new(Memmap(BlockType::$sparse_ty), $sparse_name));
 
             )*
 

--- a/hyena-engine/src/lib.rs
+++ b/hyena-engine/src/lib.rs
@@ -55,7 +55,7 @@ pub use self::error::{Error, Result};
 pub use self::scanner::{ScanFilters, Scan, ScanTsRange, ScanFilterOp, ScanResult, ScanFilterApply,
     ScanFilter, ScanData};
 pub use self::datastore::{Catalog, Column, ColumnMap};
-pub use self::ty::{RowId, ColumnId, BlockType as BlockStorageType};
+pub use self::ty::{RowId, ColumnId, BlockStorageType};
 pub use self::block::{BlockType, SparseIndex};
 pub use self::ty::fragment::{Fragment, FragmentIter, TimestampFragment};
 pub use self::ty::block::memory::Block as MemoryBlock;

--- a/hyena-engine/src/lib.rs
+++ b/hyena-engine/src/lib.rs
@@ -55,7 +55,7 @@ pub use self::error::{Error, Result};
 pub use self::scanner::{ScanFilters, Scan, ScanTsRange, ScanFilterOp, ScanResult, ScanFilterApply,
     ScanFilter, ScanData};
 pub use self::datastore::{Catalog, Column, ColumnMap};
-pub use self::ty::{RowId, ColumnId, BlockStorageType};
+pub use self::ty::{RowId, ColumnId, BlockStorage};
 pub use self::block::{BlockType, SparseIndex};
 pub use self::ty::fragment::{Fragment, FragmentIter, TimestampFragment};
 pub use self::ty::block::memory::Block as MemoryBlock;

--- a/hyena-engine/src/ty/block/mod.rs
+++ b/hyena-engine/src/ty/block/mod.rs
@@ -17,31 +17,31 @@ pub type BlockMap<'block> = HashMap<BlockId, RwLock<Block<'block>>>;
 pub(crate) type BlockHeadMap = HashMap<BlockId, usize>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct BlockTypeMap(BlockTypeMapTy);
-pub(crate) type BlockTypeMapTy = HashMap<BlockId, BlockType>;
+pub struct BlockStorageTypeMap(BlockStorageTypeMapTy);
+pub(crate) type BlockStorageTypeMapTy = HashMap<BlockId, BlockStorageType>;
 
 
-impl<'block> Deref for BlockTypeMap {
-    type Target = BlockTypeMapTy;
+impl<'block> Deref for BlockStorageTypeMap {
+    type Target = BlockStorageTypeMapTy;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'block, 'a> From<&'a BlockMap<'block>> for BlockTypeMap {
-    fn from(block_map: &BlockMap) -> BlockTypeMap {
+impl<'block, 'a> From<&'a BlockMap<'block>> for BlockStorageTypeMap {
+    fn from(block_map: &BlockMap) -> BlockStorageTypeMap {
         block_map
             .iter()
             .map(|(block_id, block)| (*block_id, block.into()))
-            .collect::<BlockTypeMapTy>()
+            .collect::<BlockStorageTypeMapTy>()
             .into()
     }
 }
 
-impl From<BlockTypeMapTy> for BlockTypeMap {
-    fn from(block_hmap: BlockTypeMapTy) -> BlockTypeMap {
-        BlockTypeMap(block_hmap)
+impl From<BlockStorageTypeMapTy> for BlockStorageTypeMap {
+    fn from(block_hmap: BlockStorageTypeMapTy) -> BlockStorageTypeMap {
+        BlockStorageTypeMap(block_hmap)
     }
 }
 
@@ -53,9 +53,9 @@ pub enum Block<'block> {
 }
 
 
-impl<'block> PartialEq<BlockType> for Block<'block> {
-    fn eq(&self, rhs: &BlockType) -> bool {
-        let self_ty: BlockType = self.into();
+impl<'block> PartialEq<BlockStorageType> for Block<'block> {
+    fn eq(&self, rhs: &BlockStorageType) -> bool {
+        let self_ty: BlockStorageType = self.into();
 
         self_ty == *rhs
     }
@@ -71,24 +71,22 @@ macro_rules! block_map_expr {
     };
 }
 
-// todo: consider renaming to `BlockStorageType`
-
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub enum BlockType {
+pub enum BlockStorageType {
     Memory(block::BlockType),
     #[cfg(feature = "mmap")]
     Memmap(block::BlockType),
 }
 
-impl BlockType {
+impl BlockStorageType {
     pub fn size_of(&self) -> usize {
-        use self::BlockType::*;
+        use self::BlockStorageType::*;
 
         block_map_expr!(*self, block, { block.size_of() })
     }
 
     pub fn is_sparse(&self) -> bool {
-        use self::BlockType::*;
+        use self::BlockStorageType::*;
 
         block_map_expr!(*self, block, { block.is_sparse() })
     }
@@ -125,18 +123,18 @@ impl<'block> Block<'block> {
     }
 }
 
-impl<'block, 'a> From<&'a Block<'block>> for BlockType {
-    fn from(block: &Block) -> BlockType {
+impl<'block, 'a> From<&'a Block<'block>> for BlockStorageType {
+    fn from(block: &Block) -> BlockStorageType {
         match *block {
-            Block::Memory(ref b) => BlockType::Memory(b.into()),
+            Block::Memory(ref b) => BlockStorageType::Memory(b.into()),
             #[cfg(feature = "mmap")]
-            Block::Memmap(ref b) => BlockType::Memmap(b.into()),
+            Block::Memmap(ref b) => BlockStorageType::Memmap(b.into()),
         }
     }
 }
 
-impl<'block, 'a> From<&'a RwLock<Block<'block>>> for BlockType {
-    fn from(block: &RwLock<Block>) -> BlockType {
+impl<'block, 'a> From<&'a RwLock<Block<'block>>> for BlockStorageType {
+    fn from(block: &RwLock<Block>) -> BlockStorageType {
         (acquire!(read block)).into()
     }
 }

--- a/hyena-engine/src/ty/block/mod.rs
+++ b/hyena-engine/src/ty/block/mod.rs
@@ -138,3 +138,15 @@ impl<'block, 'a> From<&'a RwLock<Block<'block>>> for BlockStorageType {
         (acquire!(read block)).into()
     }
 }
+
+impl Deref for BlockStorageType {
+    type Target = block::BlockType;
+
+    fn deref(&self) -> &Self::Target {
+        use self::BlockStorageType::*;
+
+        match *self {
+            Memory(ref bt) | Memmap(ref bt) => bt,
+        }
+    }
+}

--- a/hyena-engine/src/ty/mod.rs
+++ b/hyena-engine/src/ty/mod.rs
@@ -4,8 +4,8 @@ pub(super) mod block;
 #[macro_use]
 pub mod fragment;
 
-pub(crate) use self::block::{BlockHeadMap, BlockId, BlockMap, BlockStorageTypeMap};
-pub use self::block::BlockStorageType;
+pub(crate) use self::block::{BlockHeadMap, BlockMap, BlockStorageMap, BlockStorageMapType};
+pub use self::block::{BlockStorage, BlockStorageType};
 pub use self::fragment::{Fragment, FragmentRef, TimestampFragment};
 
 pub type ColumnId = usize;

--- a/hyena-engine/src/ty/mod.rs
+++ b/hyena-engine/src/ty/mod.rs
@@ -4,8 +4,8 @@ pub(super) mod block;
 #[macro_use]
 pub mod fragment;
 
-pub(crate) use self::block::{BlockHeadMap, BlockId, BlockMap, BlockTypeMap};
-pub use self::block::BlockType;
+pub(crate) use self::block::{BlockHeadMap, BlockId, BlockMap, BlockStorageTypeMap};
+pub use self::block::BlockStorageType;
 pub use self::fragment::{Fragment, FragmentRef, TimestampFragment};
 
 pub type ColumnId = usize;

--- a/hyena-engine/tests/catalog.rs
+++ b/hyena-engine/tests/catalog.rs
@@ -3,7 +3,7 @@ extern crate failure;
 
 use failure::ResultExt;
 
-use hyena_engine::{Append, BlockData, BlockStorageType, BlockType, Catalog, Column, ColumnMap,
+use hyena_engine::{Append, BlockData, BlockStorage, BlockType, Catalog, Column, ColumnMap,
                    Fragment, Scan, ScanFilter, ScanFilterOp, ScanResult,
                    SparseIndex, Timestamp, TimestampFragment};
 
@@ -41,9 +41,9 @@ fn it_adds_new_column_catalog() {
         let mut column_map = ColumnMap::new();
 
         column_map.insert(2, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Dense), "dense1"));
+            BlockStorage::Memmap(BlockType::U64Dense), "dense1"));
         column_map.insert(3, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Sparse), "sparse1"));
+            BlockStorage::Memmap(BlockType::U64Sparse), "sparse1"));
 
         cat.add_columns(column_map)?;
 
@@ -107,9 +107,9 @@ fn it_appends_data() {
         let mut column_map = ColumnMap::new();
 
         column_map.insert(2, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Dense), "dense1"));
+            BlockStorage::Memmap(BlockType::U64Dense), "dense1"));
         column_map.insert(3, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Sparse), "sparse1"));
+            BlockStorage::Memmap(BlockType::U64Sparse), "sparse1"));
 
         cat.add_columns(column_map)?;
 
@@ -141,9 +141,9 @@ fn it_scans() {
         let mut column_map = ColumnMap::new();
 
         column_map.insert(2, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Dense), "dense1"));
+            BlockStorage::Memmap(BlockType::U64Dense), "dense1"));
         column_map.insert(3, Column::new(
-            BlockStorageType::Memmap(BlockType::U64Sparse), "sparse1"));
+            BlockStorage::Memmap(BlockType::U64Sparse), "sparse1"));
 
         cat.add_columns(column_map)?;
 

--- a/hyena-engine/tests/large.rs
+++ b/hyena-engine/tests/large.rs
@@ -1,6 +1,6 @@
 extern crate hyena_engine;
 
-use hyena_engine::{Append, BlockData, BlockStorageType, BlockType, Catalog, Column, ColumnMap,
+use hyena_engine::{Append, BlockData, BlockStorage, BlockType, Catalog, Column, ColumnMap,
                    Fragment, SparseIndex, Timestamp, TimestampFragment};
 use std::iter::{once, repeat};
 
@@ -14,11 +14,11 @@ use common::{catalog_dir, get_columns, wrap_result};
 fn build_schema() -> ColumnMap {
     (2..102).map(|idx| {
         let name = format!("dense{}", idx);
-        (idx, Column::new(BlockStorageType::Memmap(BlockType::U64Dense), &name))
+        (idx, Column::new(BlockStorage::Memmap(BlockType::U64Dense), &name))
     }).chain(
         (102..1102).map(|idx| {
             let name = format!("sparse{}", idx);
-            (idx, Column::new(BlockStorageType::Memmap(BlockType::U64Sparse), &name))
+            (idx, Column::new(BlockStorage::Memmap(BlockType::U64Sparse), &name))
         })
     ).collect()
 }

--- a/hyena-engine/tests/scan.rs
+++ b/hyena-engine/tests/scan.rs
@@ -2,7 +2,7 @@ extern crate hyena_engine;
 extern crate hyena_test;
 extern crate failure;
 
-use hyena_engine::{Append, BlockData, BlockStorageType, BlockType, Catalog, Column, ColumnMap,
+use hyena_engine::{Append, BlockData, BlockStorage, BlockType, Catalog, Column, ColumnMap,
                    Fragment, Result, Scan, ScanFilter, ScanFilterOp, ScanResult,
                    SparseIndex, Timestamp, TimestampFragment};
 
@@ -84,13 +84,13 @@ fn prepare_data<'cat>(record_count: usize) -> Result<(Timestamp, TempDir, Catalo
     let mut column_map = ColumnMap::new();
 
     column_map.insert(2, Column::new(
-        BlockStorageType::Memmap(BlockType::U64Dense), "dense1"));
+        BlockStorage::Memmap(BlockType::U64Dense), "dense1"));
     column_map.insert(3, Column::new(
-        BlockStorageType::Memmap(BlockType::I32Dense), "dense2"));
+        BlockStorage::Memmap(BlockType::I32Dense), "dense2"));
     column_map.insert(4, Column::new(
-        BlockStorageType::Memmap(BlockType::U64Sparse), "sparse1"));
+        BlockStorage::Memmap(BlockType::U64Sparse), "sparse1"));
     column_map.insert(5, Column::new(
-        BlockStorageType::Memmap(BlockType::I64Sparse), "sparse2"));
+        BlockStorage::Memmap(BlockType::I64Sparse), "sparse2"));
 
     cat.add_columns(column_map)?;
 


### PR DESCRIPTION
Rename ty::BlockType to BlockStorageType.
This was in conflict with block::BlockType enum.

To do: API improvements suggested in #11 